### PR TITLE
fix: load remote schema

### DIFF
--- a/introspection/type.go
+++ b/introspection/type.go
@@ -69,7 +69,7 @@ type Query struct {
 		SubscriptionType *struct{ Name *string }
 		Types            FullTypes
 		Directives       []*DirectiveType
-	} `graphql:"__schema"`
+	} `json:"__schema"`
 }
 
 type DirectiveType struct {


### PR DESCRIPTION
Loading a remote schema using the `endpoint` config option fails, because the program cannot unmarshal the received data. The problem stems from an misnamed stuct tag on the `Query` type.