### PR TITLE
remove "<TYPE> is already declared" log

### DIFF
--- a/clientgen/source_generator.go
+++ b/clientgen/source_generator.go
@@ -243,7 +243,6 @@ func (r *SourceGenerator) namedType(path FieldPath, gen func() types.Type) types
 
 	if r.cfg.Models.Exists(fullname) && len(r.cfg.Models[fullname].Model) > 0 {
 		model := r.cfg.Models[fullname].Model[0]
-		fmt.Printf("%s is already declared: %v\n", fullname, model)
 
 		typ, err := r.binder.FindTypeFromName(model)
 		if err != nil {


### PR DESCRIPTION
When working with bigger schemas, my generate output was flooded with `<TYPE> is already declared` messages. They provide no additional insight, as an error message will be printed if the scalar is not predeclared. This PR removes these logs in order to improve readability of generate output.